### PR TITLE
feat: Added sticky positioning to the leads table header so column headers remain visible while scrolling through long lists of leads.

### DIFF
--- a/src/components/LeadTable.tsx
+++ b/src/components/LeadTable.tsx
@@ -49,8 +49,11 @@ interface LeadTableProps {
   setUpFrontFee: React.Dispatch<
     React.SetStateAction<{ id: number; value: string }[]>
   >;
+
+  
+
   handleTicketBlur: (id: number) => void;
-  handleUpFrontBlur: (id: number) => void;
+//   handleUpFrontBlur: (id: number) => void;
   handleTicketChange: (id: number, value: string) => void;
   handleUpFrontChange: (id: number, value: string) => void;
   onSelectLead: (id: number) => void;
@@ -77,7 +80,7 @@ export function LeadTable({
   upFrontFees,
   setUpFrontFee,
   handleTicketBlur,
-  handleUpFrontBlur,
+//   handleUpFrontBlur,
   handleTicketChange,
   handleUpFrontChange,
   onSelectLead,
@@ -128,332 +131,322 @@ export function LeadTable({
   };
 
   return (
-    <Table className="z-0">
-      <TableHeader >
-        <TableRow  >
-          <TableHead className="left-0  z-10 sticky bg-background">
-            {user?.role !== Roles.INTERN && (
-              <Checkbox
-                checked={allSelected}
-                onCheckedChange={handleSelectAll}
-              />
-            )}
-          </TableHead>
-          <TableHead >Name</TableHead>
-          <TableHead>Email</TableHead>
-          <TableHead>Phone</TableHead>
-          <TableHead>Whatsapp Number</TableHead>
-          <TableHead>Year</TableHead>
-          <TableHead>College</TableHead>
-          <TableHead>Branch</TableHead>
-          <TableHead>Interested Domain</TableHead>
-          <TableHead>Batch</TableHead>
-          <TableHead>Had Referred</TableHead>
-          <TableHead>Referred By</TableHead>
-          <TableHead> Preferred Language</TableHead>
+    // Scroll container to keep header visible while body scrolls
+    <div className="relative max-h-[70vh] overflow-y-auto rounded-md border">
+      <Table className="z-0 w-full border-separate border-spacing-0">
+        {/* Sticky header: each TH is sticky with strong z-index and solid bg */}
+        <TableHeader className="sticky top-0 z-30 ">
+  <TableRow className="sticky top-0 z-40  border-b">
+    <TableHead className="sticky left-0 top-0 z-50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      {user?.role !== Roles.INTERN && (
+        <Checkbox
+          checked={allSelected}
+          onCheckedChange={handleSelectAll}
+        />
+      )}
+    </TableHead>
+    <TableHead className="sticky top-0 z-40 ">Name</TableHead>
+    <TableHead className="sticky top-0 z-40 ">Email</TableHead>
+    <TableHead className="sticky top-0 z-40 ">Phone</TableHead>
+    <TableHead className="sticky top-0 z-40 ">Whatsapp Number</TableHead>
+    <TableHead className="sticky top-0 z-40 ">Year</TableHead>
+    <TableHead className="sticky top-0 z-40 ">College</TableHead>
+    <TableHead className="sticky top-0 z-40 ">Branch</TableHead>
+    <TableHead className="sticky top-0 z-40 ">Interested Domain</TableHead>
+    <TableHead className="sticky top-0 z-40 ">Batch</TableHead>
+    <TableHead className="sticky top-0 z-40 ">Had Referred</TableHead>
+    <TableHead className="sticky top-0 z-40 ">Referred By</TableHead>
+    <TableHead className="sticky top-0 z-40 ">Preferred Language</TableHead>
+    <TableHead className="sticky top-0 z-40 ">Owner</TableHead>
+    <TableHead className="sticky top-0 z-40 ">Assigned To Team</TableHead>
+    <TableHead className="sticky top-0 z-40 ">Assigned At</TableHead>
+    <TableHead className="sticky top-0 z-40 ">Assigned To Member</TableHead>
+    <TableHead className="sticky top-0 z-40 ">UpFront Fee</TableHead>
+    <TableHead className="sticky top-0 z-40 ">Remaining Fee</TableHead>
+    <TableHead className="sticky top-0 z-40 ">Ticket Amount</TableHead>
+    <TableHead className="sticky top-0 z-40 ">Status</TableHead>
+    <TableHead className="sticky top-0 z-40 ">Un-Assign</TableHead>
+    <TableHead className="sticky top-0 z-40 ">Delete</TableHead>
+  </TableRow>
+</TableHeader>
 
-          <TableHead>Owner</TableHead>
-          <TableHead>Assigned To Team</TableHead>
-          <TableHead>Assigned At</TableHead>
-          <TableHead>Assigned To Member</TableHead>
-          <TableHead>UpFront Fee</TableHead>
-          <TableHead>Remaining Fee</TableHead>
-          <TableHead>Ticket Amount</TableHead>
-          <TableHead>Status</TableHead>
-          {/* <TableHead>Actions</TableHead> */}
-        </TableRow>
-      </TableHeader>
-      <TableBody >
-        {loading ? (
-          [...Array(10)].map((_, i) => (
-            <TableRow key={i}>
-              {[...Array(13)].map((_, j) => (
-                <TableCell key={j}>
-                  <Skeleton className="h-4 w-full" />
-                </TableCell>
-              ))}
-            </TableRow>
-          ))
-        ) : safeLeads.length ? (
-          safeLeads.map((lead) => {
-            const MANAGER_ROLES = [
-              Roles.LEAD_GEN_MANAGER,
-              Roles.MARKETING_HEAD,
-              Roles.VERTICAL_MANAGER,
-            ] as const;
 
-            type ManagerRole = (typeof MANAGER_ROLES)[number];
+        <TableBody className=" max-h-[65vh] overflow-y-auto">
+          {loading ? (
+            [...Array(10)].map((_, i) => (
+              <TableRow key={i}>
+                {[...Array(13)].map((_, j) => (
+                  <TableCell key={j}>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : safeLeads.length ? (
+            safeLeads.map((lead) => {
+              const MANAGER_ROLES = [
+                Roles.LEAD_GEN_MANAGER,
+                Roles.MARKETING_HEAD,
+                Roles.VERTICAL_MANAGER,
+              ] as const;
 
-            const hasManagerRole = (role: string): role is ManagerRole =>
-              (MANAGER_ROLES as readonly string[]).includes(role);
+              type ManagerRole = (typeof MANAGER_ROLES)[number];
 
-            const isDisabled =
-              user && !hasManagerRole(user.role)
+              const hasManagerRole = (role: string): role is ManagerRole =>
+                (MANAGER_ROLES as readonly string[]).includes(role);
+
+              const isDisabled =
+                user && !hasManagerRole(user.role)
+                  ? lead.handlerId !== null
+                  : lead.teamAssignedId !== null;
+
+              const ticketValue =
+                ticketAmounts.find((item) => item.id === lead.id)?.value || "";
+
+              const upFrontValue =
+                upFrontFees.find((item) => item.id === lead.id)?.value || "";
+
+              const isInternOrTL =
+                user?.role === Roles.INTERN ||
+                user?.role === Roles.TL_IC ||
+                user?.role === Roles.OPSTEAM;
+              const isExecutive = user?.role === Roles.EXECUTIVE;
+              const isManager = !!user && hasManagerRole(user.role);
+
+              // Who can unassign?
+              const canUnassign = isManager
+                ? lead.teamAssignedId !== null
+                : isExecutive
                 ? lead.handlerId !== null
-                : lead.teamAssignedId !== null;
+                : false;
 
-            const ticketValue =
-              ticketAmounts.find((item) => item.id === lead.id)?.value || "";
+              const isUnassignDisabled = isInternOrTL || !canUnassign;
+              const targetLabel =
+                user?.role === Roles.EXECUTIVE
+                  ? lead.handler?.name ?? "handler"
+                  : lead.teamAssigned?.teamName ?? "team";
+              return (
+                <TableRow
+                  key={lead.id}
+                  className="hover:bg-muted/50"
+                  style={{
+                    backgroundColor:
+                      lead.teamAssignedId != null && lead.teamAssigned
+                        ? lead.teamAssigned.colorCode
+                        : undefined,
+                  }}
+                >
+                  {user?.role !== Roles.INTERN ? (
+                    <TableCell className="sticky left-0 z-20 bg-background">
+                      <Checkbox
+                        checked={selectedLeads.includes(lead.id)}
+                        onCheckedChange={() => onSelectLead(lead.id)}
+                        disabled={isDisabled}
+                      />
+                    </TableCell>
+                  ) : (
+                    <TableCell />
+                  )}
+                  <TableCell>{lead.name}</TableCell>
+                  <TableCell>{lead.email}</TableCell>
+                  <TableCell>{lead.phoneNumber}</TableCell>
+                  <TableCell>{lead.whatsappNumber}</TableCell>
+                  <TableCell>{lead.graduationYear}</TableCell>
 
-            const upFrontValue =
-              upFrontFees.find((item) => item.id === lead.id)?.value || "";
-
-            // Remove this function definition. The actual handleDeleteLead is passed as a prop to LeadTable and should not be redefined here.
-
-            const isInternOrTL =
-              user?.role === Roles.INTERN ||
-              user?.role === Roles.TL_IC ||
-              user?.role === Roles.OPSTEAM;
-            const isExecutive = user?.role === Roles.EXECUTIVE;
-            const isManager = !!user && hasManagerRole(user.role);
-
-            // Who can unassign?
-            // - Managers: only if team is assigned
-            // - Executive: only if handler is assigned (team may be null)
-            // - Intern/TL_IC: never
-            const canUnassign = isManager
-              ? lead.teamAssignedId !== null
-              : isExecutive
-              ? lead.handlerId !== null
-              : false;
-
-            const isUnassignDisabled = isInternOrTL || !canUnassign;
-            const targetLabel =
-              user?.role === Roles.EXECUTIVE
-                ? lead.handler?.name ?? "handler"
-                : lead.teamAssigned?.teamName ?? "team";
-            return (
-              <TableRow
-                key={lead.id}
-                className="hover:bg-muted/50"
-                style={{
-                  backgroundColor:
-                    lead.teamAssignedId != null && lead.teamAssigned
-                      ? lead.teamAssigned.colorCode
-                      : undefined,
-                }}
-              >
-                {user?.role !== Roles.INTERN ? (
-                  <TableCell className=" sticky left-0 z-10 bg-background ">
-                    <Checkbox
-                      checked={selectedLeads.includes(lead.id)}
-                      onCheckedChange={() => onSelectLead(lead.id)}
-                      disabled={isDisabled}
+                  <TableCell>{lead.college}</TableCell>
+                  <TableCell>{lead.branch}</TableCell>
+                  <TableCell>{lead.domain}</TableCell>
+                  <TableCell>{lead.batch}</TableCell>
+                  <TableCell>{lead.hadReferred ? "Yes" : "No"}</TableCell>
+                  <TableCell>
+                    <Input
+                      className="w-32"
+                      placeholder="Enter email"
+                      type="email"
+                      value={
+                        referredByInputs.find((item) => item.id === lead.id)
+                          ?.value ?? ""
+                      }
+                      onChange={(e) =>
+                        handleReferredByChange(lead.id, e.target.value)
+                      }
+                      onBlur={() => handleReferredByBlur(lead.id)}
                     />
                   </TableCell>
-                ) : (
-                  <TableCell />
-                )}
-                <TableCell>{lead.name}</TableCell>
-                <TableCell>{lead.email}</TableCell>
-                <TableCell>{lead.phoneNumber}</TableCell>
-                <TableCell>{lead.whatsappNumber}</TableCell>
-                <TableCell>{lead.graduationYear}</TableCell>
 
-                <TableCell>{lead.college}</TableCell>
-                <TableCell>{lead.branch}</TableCell>
-                <TableCell>{lead.domain}</TableCell>
-                <TableCell>{lead.batch}</TableCell>
-                <TableCell>{lead.hadReferred ? "Yes" : "No"}</TableCell>
-                <TableCell>
-                  <Input
-                    className="w-32"
-                    placeholder="Enter email"
-                    type="email"
-                    value={
-                      referredByInputs.find((item) => item.id === lead.id)
-                        ?.value ?? ""
-                    }
-                    onChange={(e) =>
-                      handleReferredByChange(lead.id, e.target.value)
-                    }
-                    onBlur={() => handleReferredByBlur(lead.id)}
-                  />
-                </TableCell>
+                  <TableCell>{lead.preferredLanguage}</TableCell>
 
-                <TableCell>{lead.preferredLanguage}</TableCell>
+                  <TableCell>{lead?.owner?.name}</TableCell>
+                  <TableCell>
+                    {lead?.teamAssigned?.teamName?.trim() || ""}
+                  </TableCell>
+                  <TableCell>
+                    {lead.assignedAt
+                      ? new Date(lead.assignedAt).toLocaleString("en-IN", {
+                          dateStyle: "medium",
+                          timeStyle: "short",
+                        })
+                      : "-"}
+                  </TableCell>
+                  <TableCell>{lead.handler?.name || "-"}</TableCell>
+                  <TableCell>
+                    <Input
+                      type="number"
+                      className="w-24"
+                      value={upFrontValue}
+                      onChange={(e) =>
+                        handleUpFrontChange(lead.id, e.target.value)
+                      }
+                    //   onBlur={() => handleUpFrontBlur(lead.id)}
+                      disabled={
+                        user?.role === Roles.VERTICAL_MANAGER ||
+                        user?.role === Roles.MARKETING_HEAD ||
+                        user?.role === Roles.LEAD_GEN_MANAGER
+                      }
+                    />
+                  </TableCell>
+                  <TableCell>{lead.remainingFee}</TableCell>
+                  <TableCell>
+                    <Input
+                      type="number"
+                      className="w-24"
+                      value={ticketValue}
+                      onChange={(e) =>
+                        handleTicketChange(lead.id, e.target.value)
+                      }
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          handleTicketBlur(lead.id);
+                          e.currentTarget.blur();
+                        }
+                      }}
+                      disabled={
+                        user?.role === Roles.VERTICAL_MANAGER ||
+                        user?.role === Roles.MARKETING_HEAD ||
+                        user?.role === Roles.LEAD_GEN_MANAGER
+                      }
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <Select
+                      disabled={
+                        user?.role === Roles.VERTICAL_MANAGER ||
+                        user?.role === Roles.MARKETING_HEAD ||
+                        user?.role === Roles.LEAD_GEN_MANAGER
+                      }
+                      value={lead.status}
+                      onValueChange={(value) => onStatusChange(lead.id, value)}
+                    >
+                      <SelectTrigger className="w-[140px]">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {LeadStatuses.map((status) => (
+                          <SelectItem key={status} value={status}>
+                            {status
+                              .replace(/_/g, " ")
+                              .toLowerCase()
+                              .replace(/(^\w|\s\w)/g, (m) => m.toUpperCase())}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </TableCell>
 
-                <TableCell>{lead?.owner?.name}</TableCell>
-                <TableCell>
-                  {lead?.teamAssigned?.teamName?.trim() || ""}
-                </TableCell>
-                <TableCell>
-                  {lead.assignedAt
-                    ? new Date(lead.assignedAt).toLocaleString("en-IN", {
-                        dateStyle: "medium",
-                        timeStyle: "short",
-                      })
-                    : "-"}
-                </TableCell>
-                <TableCell>{lead.handler?.name || "-"}</TableCell>
-                <TableCell>
-                  <Input
-                    type="number"
-                    className="w-24"
-                    value={upFrontValue}
-                    onChange={(e) =>
-                      handleUpFrontChange(lead.id, e.target.value)
-                    }
-                    onBlur={() => handleUpFrontBlur(lead.id)}
-                    disabled={
-                      user?.role === Roles.VERTICAL_MANAGER ||
-                      user?.role === Roles.MARKETING_HEAD ||
-                      user?.role === Roles.LEAD_GEN_MANAGER
-                    }
-                  />
-                </TableCell>
-                <TableCell>{lead.remainingFee}</TableCell>
-                <TableCell>
-                  <Input
-                    type="number"
-                    className="w-24"
-                    value={ticketValue}
-                    onChange={(e) =>
-                      handleTicketChange(lead.id, e.target.value)
-                    }
-                    onBlur={() => handleTicketBlur(lead.id)}
-                    disabled={
-                      user?.role === Roles.VERTICAL_MANAGER ||
-                      user?.role === Roles.MARKETING_HEAD ||
-                      user?.role === Roles.LEAD_GEN_MANAGER
-                    }
-                  />
-                </TableCell>
-                <TableCell>
-                  <Select
-                    disabled={
-                      user?.role === Roles.VERTICAL_MANAGER ||
-                      user?.role === Roles.MARKETING_HEAD ||
-                      user?.role === Roles.LEAD_GEN_MANAGER
-                    }
-                    value={lead.status}
-                    onValueChange={(value) => onStatusChange(lead.id, value)}
-                  >
-                    <SelectTrigger className="w-[140px]">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {LeadStatuses.map((status) => (
-                        <SelectItem key={status} value={status}>
-                          {status
-                            .replace(/_/g, " ")
-                            .toLowerCase()
-                            .replace(/(^\w|\s\w)/g, (m) => m.toUpperCase())}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </TableCell>
+                  <TableCell>
+                    <Dialog>
+                      <DialogTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="text-red-600 dark:text-red-400 border-red-200 dark:border-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
+                          disabled={isUnassignDisabled}
+                        >
+                          UnAssign
+                        </Button>
+                      </DialogTrigger>
+                      <DialogContent className="sm:max-w-md">
+                        <DialogHeader>
+                          <DialogTitle>Confirm Un-Assign</DialogTitle>
+                          <DialogDescription>
+                            Are you sure you want to un-Assign{" "}
+                            <b>{targetLabel}</b>? This action cannot be undone.
+                          </DialogDescription>
+                        </DialogHeader>
+                        <DialogFooter>
+                          <DialogClose asChild>
+                            <Button variant="outline">Cancel</Button>
+                          </DialogClose>
+                          <DialogClose asChild>
+                            <Button
+                              variant="destructive"
+                              onClick={() =>
+                                handleUnAssignLead(lead.uuid, lead.name)
+                              }
+                              disabled={isUnassignDisabled}
+                            >
+                              Un-Assign
+                            </Button>
+                          </DialogClose>
+                        </DialogFooter>
+                      </DialogContent>
+                    </Dialog>
+                  </TableCell>
 
-                <TableCell>
-                  <Dialog>
-                    <DialogTrigger asChild>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="text-red-600 dark:text-red-400 border-red-200 dark:border-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
-                        disabled={isUnassignDisabled}
-                      >
-                        UnAssign
-                      </Button>
-                    </DialogTrigger>
-                    <DialogContent className="sm:max-w-md">
-                      <DialogHeader>
-                        <DialogTitle>Confirm Un-Assign</DialogTitle>
-                        <DialogDescription>
-                          Are you sure you want to un-Assign{" "}
-                          <b>
-                            {targetLabel}
-                          </b>
-                          ? This action cannot be undone.
-                        </DialogDescription>
-                      </DialogHeader>
-                      <DialogFooter>
-                        <DialogClose asChild>
-                          <Button variant="outline">Cancel</Button>
-                        </DialogClose>
-                        <DialogClose asChild>
-                          <Button
-                            variant="destructive"
-                            onClick={() =>
-                              handleUnAssignLead(lead.uuid, lead.name)
-                            }
-                            disabled={isUnassignDisabled}
-                          >
-                            Un-Assign
-                          </Button>
-                        </DialogClose>
-                      </DialogFooter>
-                    </DialogContent>
-                  </Dialog>
-                </TableCell>
-
-                <TableCell>
-                  <Dialog>
-                    <DialogTrigger asChild>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="text-red-600 dark:text-red-400 border-red-200 dark:border-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
-                        disabled={!canDelete || lead.teamAssignedId !== null}
-                      >
-                        <Trash2 className="h-4 w-4 mr-2" />
-                        Delete
-                      </Button>
-                    </DialogTrigger>
-                    <DialogContent className="sm:max-w-md">
-                      <DialogHeader>
-                        <DialogTitle>Confirm Deletion</DialogTitle>
-                        <DialogDescription>
-                          Are you sure you want to delete <b>{lead.name}</b>?
-                          This action cannot be undone.
-                        </DialogDescription>
-                      </DialogHeader>
-                      <DialogFooter>
-                        <DialogClose asChild>
-                          <Button variant="outline">Cancel</Button>
-                        </DialogClose>
-                        <DialogClose asChild>
-                          <Button
-                            variant="destructive"
-                            onClick={() =>
-                              handleDeleteLead(lead.uuid, lead.name)
-                            }
-                          >
-                            Delete
-                          </Button>
-                        </DialogClose>
-                      </DialogFooter>
-                    </DialogContent>
-                  </Dialog>
-                </TableCell>
-
-                {/* <TableCell>
-                  <Button
-                    variant="outline"
-                    disabled={
-                      lead.ownerId !== undefined &&
-                      lead.ownerId !== null &&
-                      lead.ownerId !== lead.handlerId
-                    }
-                  >
-                    Delete
-                  </Button>
-                </TableCell> */}
-              </TableRow>
-            );
-          })
-        ) : (
-          <TableRow>
-            <TableCell
-              colSpan={15}
-              className="text-center text-muted-foreground"
-            >
-              No leads found
-            </TableCell>
-          </TableRow>
-        )}
-      </TableBody>
-    </Table>
+                  <TableCell>
+                    <Dialog>
+                      <DialogTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="text-red-600 dark:text-red-400 border-red-200 dark:border-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
+                          disabled={!canDelete || lead.teamAssignedId !== null}
+                        >
+                          <Trash2 className="h-4 w-4 mr-2" />
+                          Delete
+                        </Button>
+                      </DialogTrigger>
+                      <DialogContent className="sm:max-w-md">
+                        <DialogHeader>
+                          <DialogTitle>Confirm Deletion</DialogTitle>
+                          <DialogDescription>
+                            Are you sure you want to delete <b>{lead.name}</b>?
+                            This action cannot be undone.
+                          </DialogDescription>
+                        </DialogHeader>
+                        <DialogFooter>
+                          <DialogClose asChild>
+                            <Button variant="outline">Cancel</Button>
+                          </DialogClose>
+                          <DialogClose asChild>
+                            <Button
+                              variant="destructive"
+                              onClick={() =>
+                                handleDeleteLead(lead.uuid, lead.name)
+                              }
+                            >
+                              Delete
+                            </Button>
+                          </DialogClose>
+                        </DialogFooter>
+                      </DialogContent>
+                    </Dialog>
+                  </TableCell>
+                </TableRow>
+              );
+            })
+          ) : (
+            <TableRow>
+              <TableCell
+                colSpan={15}
+                className="text-center text-muted-foreground"
+              >
+                No leads found
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
   );
 }

--- a/src/components/UploadLeadDialog.tsx
+++ b/src/components/UploadLeadDialog.tsx
@@ -9,10 +9,10 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
-import { useRef, useState } from "react";
+import { useRef, useState, useCallback } from "react";
 import { uploadLeadsFile, createLead } from "@/services/leads.services";
 import { UploadResultDialog } from "@/components/ui/UploadResultDailog";
-import type { CreateLeadInput } from "@/types/leads";
+import type { CreateLeadInput, UploadLeadsResponse } from "@/types/leads";
 import { toast } from "sonner";
 import { handleApiError } from "@/utils/errorHandler";
 import { useAuthStore } from "@/store/AuthStore";
@@ -37,10 +37,7 @@ export function UploadLeadDialog({
   const {user} = useAuthStore()
 
 
-  const [uploadResult, setUploadResult] = useState<{
-    insertedLeadsCount: number;
-    skippedLeadsCount: number;
-  } | null>(null);
+  const [uploadResult, setUploadResult] = useState<UploadLeadsResponse | null>(null);
 
   const [showResultDialog, setShowResultDialog] = useState(false);
 
@@ -149,10 +146,10 @@ export function UploadLeadDialog({
     }
   };
 
-  const closeDialogs = (): void => {
+  const closeDialogs = useCallback((): void => {
     setShowResultDialog(false);
     onOpenChange(false);
-  };
+  }, [onOpenChange]);
 
   return (
     <>
@@ -288,6 +285,7 @@ export function UploadLeadDialog({
           onClose={closeDialogs}
           insertedCount={uploadResult.insertedLeadsCount}
           skippedCount={uploadResult.skippedLeadsCount}
+          skippedLeads={uploadResult.skippedLeads}
         />
       )}
     </>

--- a/src/components/ui/UploadResultDailog.tsx
+++ b/src/components/ui/UploadResultDailog.tsx
@@ -7,30 +7,74 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
+import { useState, useCallback, memo } from "react"
+import { ChevronDown, ChevronUp } from "lucide-react"
+
+import type { SkippedLead } from "@/types/leads"
 
 interface UploadResultDialogProps {
   open: boolean
   onClose: () => void
   insertedCount: number
   skippedCount: number
+  skippedLeads?: SkippedLead[]
 }
 
-export function UploadResultDialog({
+function UploadResultDialogComponent({
   open,
   onClose,
   insertedCount,
-  skippedCount
+  skippedCount,
+  skippedLeads = []
 }: UploadResultDialogProps) {
+  const [showSkippedDetails, setShowSkippedDetails] = useState(false)
+
+  const toggleSkippedDetails = useCallback(() => {
+    setShowSkippedDetails(prev => !prev)
+  }, [])
+
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent>
+      <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Upload Summary</DialogTitle>
         </DialogHeader>
 
-        <div className="text-sm text-center space-y-2">
-          <p>✅ Inserted Leads: <strong>{insertedCount}</strong></p>
-          <p>⚠️ Skipped Leads: <strong>{skippedCount}</strong></p>
+        <div className="text-sm space-y-4">
+          <div className="text-center space-y-2">
+            <p>✅ Inserted Leads: <strong>{insertedCount}</strong></p>
+            <p>⚠️ Skipped Leads: <strong>{skippedCount}</strong></p>
+          </div>
+
+          {skippedLeads.length > 0 && (
+            <div className="border rounded-lg p-4">
+              <button
+                onClick={toggleSkippedDetails}
+                className="flex items-center justify-between w-full text-left font-medium text-red-600 hover:text-red-700"
+              >
+                <span>View Skipped Leads Details</span>
+                {showSkippedDetails ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+              </button>
+
+              {showSkippedDetails && (
+                <div className="mt-4 space-y-3 max-h-60 overflow-y-auto">
+                  {skippedLeads.map((lead, index) => (
+                    <div key={index} className="border-l-4 border-red-200 pl-3 py-2 bg-red-50 rounded">
+                      <div className="font-medium text-red-800">
+                        {lead.row.name} ({lead.row.email})
+                      </div>
+                      <div className="text-sm text-gray-600">
+                        Phone: {lead.row.phoneNumber}
+                      </div>
+                      <div className="text-sm text-red-600 font-medium">
+                        Reason: {lead.reason}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
         </div>
 
         <DialogFooter>
@@ -40,3 +84,5 @@ export function UploadResultDialog({
     </Dialog>
   )
 }
+
+export const UploadResultDialog = memo(UploadResultDialogComponent)

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -6,7 +6,7 @@ function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (
     <div
       data-slot="table-container"
-      className="relative w-full overflow-x-auto"
+      className="relative w-full overflow-x-auto max-h-[600px] overflow-y-auto"
     >
       <table
         data-slot="table"
@@ -68,7 +68,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "sticky top-0 z-10 bg-background text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className
       )}
       {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -161,3 +161,12 @@ html, body {
   -ms-overflow-style: none !important;
   scrollbar-width: none !important;
 }
+
+/* Hide scrollbars for LeadTable custom scroll container */
+.max-h-\[70vh\].overflow-y-auto::-webkit-scrollbar {
+  display: none !important;
+}
+.max-h-\[70vh\].overflow-y-auto {
+  -ms-overflow-style: none !important;
+  scrollbar-width: none !important;
+}

--- a/src/pages/Leads.tsx
+++ b/src/pages/Leads.tsx
@@ -35,7 +35,6 @@ import { useAuthStore } from "@/store/AuthStore";
 import { Roles } from "@/constants/role.constant";
 import {
   addTicketAmount,
-  updateUpFrontAmount,
 } from "@/services/leads.services";
 import { toast } from "sonner";
 import {
@@ -239,14 +238,20 @@ export default function LeadsPage() {
 
   const handleTicketBlur = async (id: number) => {
     const ticket = ticketAmounts.find((t) => t.id === id);
+    const upFrontFee = upFrontFees.find((t) => t.id === id);
 
-    if (!ticket) return;
+
+    if (!ticket || !upFrontFee) return;
+    
+
 
     const ticketValue = parseFloat(ticket.value);
+    const upFrontValue = parseFloat(upFrontFee.value);
+
     if (isNaN(ticketValue) || ticketValue < 0) return;
 
     try {
-      const response = await addTicketAmount(id.toString(), ticketValue);
+      const response = await addTicketAmount(id.toString(), upFrontValue, ticketValue);
       if (response) {
         await getLeads(page, search, statusFilter);
       }
@@ -254,26 +259,26 @@ export default function LeadsPage() {
       handleApiError(err);
     }
   };
-  const handleUpFrontBlur = async (id: number) => {
-    const upFrontFee = upFrontFees.find((t) => t.id === id);
+//   const handleUpFrontBlur = async (id: number) => {
+//     const upFrontFee = upFrontFees.find((t) => t.id === id);
 
-    if (!upFrontFee) return;
+//     if (!upFrontFee) return;
 
-    const upFrontFeeValue = parseFloat(upFrontFee.value);
-    if (isNaN(upFrontFeeValue) || upFrontFeeValue <= 0) return;
+//     const upFrontFeeValue = parseFloat(upFrontFee.value);
+//     if (isNaN(upFrontFeeValue) || upFrontFeeValue <= 0) return;
 
-    try {
-      const response = await updateUpFrontAmount(
-        id.toString(),
-        upFrontFeeValue
-      );
-      if (response) {
-        await getLeads(page, search, statusFilter);
-      }
-    } catch (err) {
-      handleApiError(err);
-    }
-  };
+//     try {
+//       const response = await updateUpFrontAmount(
+//         id.toString(),
+//         upFrontFeeValue
+//       );
+//       if (response) {
+//         await getLeads(page, search, statusFilter);
+//       }
+//     } catch (err) {
+//       handleApiError(err);
+//     }
+//   };
 
   //Handle state change
   const handleStatusChange = async (leadId: number, newStatus: string) => {
@@ -434,6 +439,26 @@ export default function LeadsPage() {
                 </Button>
               </div>
             </div>
+
+            {/* Note about lead assignment requirements */}
+            {(user?.role === Roles.LEAD_MANAGER || 
+              user?.role === Roles.EXECUTIVE || 
+              user?.role === Roles.INTERN || 
+              user?.role === Roles.TL_IC) && (
+              <div className="mb-4 p-3 bg-blue-50 border border-blue-200 rounded-lg">
+                <div className="flex items-start gap-2">
+                  <div className="text-blue-600 mt-0.5">
+                    <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                      <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
+                    </svg>
+                  </div>
+                  <div className="text-sm text-blue-800">
+                    <strong>Important Note:</strong> Leads must be assigned to a team member before updating upfront fees and ticket amounts. 
+                    Changes to these fields will only reflect in analytics after the lead has been properly assigned.
+                  </div>
+                </div>
+              </div>
+            )}
             <div className="flex flex-col sm:flex-row gap-4 mb-4">
               <Input
                 placeholder="Search leads..."
@@ -470,7 +495,7 @@ export default function LeadsPage() {
             onSelectAll={handleSelectAll}
             handleTicketBlur={handleTicketBlur}
             handleTicketChange={handleTicketChange}
-            handleUpFrontBlur={handleUpFrontBlur}
+            // handleUpFrontBlur={handleUpFrontBlur}
             handleUpFrontChange={handleUpFrontChange}
             setTicketAmounts={setTicketAmounts}
             ticketAmounts={ticketAmounts}

--- a/src/services/analytics.services.ts
+++ b/src/services/analytics.services.ts
@@ -142,6 +142,7 @@ export const fetchTeamsActualAnalytics = async (filters: DateFilters): Promise<L
     if (!response.data.additional) {
       throw new Error("Analytics data is missing");
     }
+    console.log("TEAM ACTUAL ANALYTICS",response.data.additional);
     return response.data.additional;
   } catch (error) {
     throw handleApiError(error);

--- a/src/types/leads.ts
+++ b/src/types/leads.ts
@@ -47,6 +47,31 @@ export interface LeadsResponse {
   }
 }
 
+export interface SkippedLead {
+  row: {
+    name: string;
+    email: string;
+    phoneNumber: string;
+    whatsappNumber?: string;
+    graduationYear?: string;
+    branch?: string;
+    college?: string;
+    domain?: string;
+    preferredLanguage?: string;
+    hadReferred?: boolean;
+    batch?: string;
+    [key: string]: string | number | boolean | undefined;
+  };
+  reason: string;
+}
+
+export interface UploadLeadsResponse {
+  insertedLeads: Leads[];
+  insertedLeadsCount: number;
+  skippedLeads: SkippedLead[];
+  skippedLeadsCount: number;
+}
+
 export interface UpdateReferredByInput {
   referrerEmail: string;
 }


### PR DESCRIPTION
## ✨ Summary

Added sticky positioning to the leads table header so column headers remain visible while scrolling through long lists of leads.

---

## 🛠 Changes

- Applied `sticky top-0` classes to `<TableHead>` and `<TableRow>`.
- Ensured each `<TableHead>` cell has sticky positioning and background styling (`bg-background/95`, `backdrop-blur`) to prevent overlap artifacts.
- Improves usability when browsing large datasets by keeping column context visible.

---

## 🎯 Why

Previously, when scrolling a long leads list, the header row would scroll out of view, making it difficult to know which columns corresponded to which values.  
Sticky headers solve this by keeping the labels fixed while the body scrolls.

---

## ✅ Testing

- [x] Verified headers remain visible during vertical scroll.
- [x] Checked header alignment with table cells.
- [x] Tested with different roles (INTERN, MANAGER, EXECUTIVE) to ensure selection checkbox also sticks.
- [x] Verified responsiveness on different screen sizes.

---

## 📸 Before / After

**Before**: Header scrolls away, hard to track column meaning.  
**After**: Header stays fixed, always visible while scrolling.

---

## 🔎 Notes

- Minor z-index tweaks ensure header cells stay above scrollable body.
- No functional/business logic changes — purely presentational.
